### PR TITLE
feat: unix time 변환 메소드

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
         tools:targetApi="31">
 
         <activity
-            android:name=".ui.SignUpActivity"
+            android:name=".ui.SignupActivity"
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/android/hanple/ui/SignupActivity.kt
+++ b/app/src/main/java/com/android/hanple/ui/SignupActivity.kt
@@ -1,22 +1,30 @@
 package com.android.hanple.ui
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.viewModels
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.Observer
 import com.android.hanple.R
 import com.android.hanple.databinding.ActivitySignUpBinding
+import com.android.hanple.utils.ConvertUtils
 
 class SignupActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySignUpBinding
     private val viewModel: SignupViewModel by viewModels()
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        //시간 변환 테스트 시작
+        Log.d("MainActivity", ConvertUtils.unixTimeConverter(1717053033).toString())
+        //1717053033 SECONDS SINCE JAN 01 1970. (UTC) 4:10:37 PM
+        //시간 변환 테스트 끝
         binding = ActivitySignUpBinding.inflate(layoutInflater)
         setContentView(binding.root)
 

--- a/app/src/main/java/com/android/hanple/utils/ConvertUtils.kt
+++ b/app/src/main/java/com/android/hanple/utils/ConvertUtils.kt
@@ -7,8 +7,12 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 
 object ConvertUtils {
-    @RequiresApi(Build.VERSION_CODES.O)
+
+    //minSdk = 24, targetSdk = 34
+    //참고한 자료: https://stackoverflow.com/questions/47250263/kotlin-convert-timestamp-to-datetime
+    @RequiresApi(Build.VERSION_CODES.O) //API level 26 이상
     fun unixTimeConverter(unixTime: Long): LocalDateTime = Instant.ofEpochSecond(unixTime)
             .atZone(ZoneId.systemDefault()) //안드로이드 OS가 확인한 현재 시간대.
             .toLocalDateTime()
+
 }

--- a/app/src/main/java/com/android/hanple/utils/ConvertUtils.kt
+++ b/app/src/main/java/com/android/hanple/utils/ConvertUtils.kt
@@ -1,0 +1,14 @@
+package com.android.hanple.utils
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+object ConvertUtils {
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun unixTimeConverter(unixTime: Long): LocalDateTime = Instant.ofEpochSecond(unixTime)
+            .atZone(ZoneId.systemDefault()) //안드로이드 OS가 확인한 현재 시간대.
+            .toLocalDateTime()
+}


### PR DESCRIPTION
package com.android.hanple.utils 에 위치해 있습니다.

object ConvertUtils {

    //minSdk = 24, targetSdk = 34
    //참고한 자료: https://stackoverflow.com/questions/47250263/kotlin-convert-timestamp-to-datetime
    @RequiresApi(Build.VERSION_CODES.O) //API level 26 이상
    fun unixTimeConverter(unixTime: Long): LocalDateTime = Instant.ofEpochSecond(unixTime)
            .atZone(ZoneId.systemDefault()) //안드로이드 OS가 확인한 현재 시간대.
            .toLocalDateTime()

}