### PR TITLE
feat: 로그인 시 firebase auth에서 계정 확인하는 기능

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.android)
     id("kotlin-parcelize")
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -118,4 +119,8 @@ dependencies {
     //gif drawable로 가져오기
     implementation ("pl.droidsonroids.gif:android-gif-drawable:1.2.28")
 
+    //firebase firestore
+    implementation(platform("com.google.firebase:firebase-bom:32.7.1"))
+    implementation("com.google.firebase:firebase-firestore")
+    implementation("com.google.firebase:firebase-auth-ktx") //firebase auth
 }

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,30 @@
+{
+  "project_info": {
+    "project_number": "420908790294",
+    "firebase_url": "https://hanple-default-rtdb.firebaseio.com",
+    "project_id": "hanple",
+    "storage_bucket": "hanple.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:420908790294:android:a4d0b49ef63c6f942dbb37",
+        "android_client_info": {
+          "package_name": "com.android.hanple"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyB-wPQ2JRSaRQsT48JyVKmPc-qB1w8Ns50"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
         android:name="android.permission.ACCESS_COARSE_LOCATION"
         tools:node="remove" />
 
-
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -24,6 +23,15 @@
         android:theme="@style/Theme.Hanple"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+        <activity
+            android:name=".ui.onboarding.OnboardingActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
@@ -31,16 +39,11 @@
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
+
         <activity
             android:name=".ui.onboarding.LogInActivity"
-            android:theme="@style/Theme.App.Starting"
-            android:exported="true" >
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:exported="true"
+            android:theme="@style/Theme.App.Starting"></activity>
         <activity
             android:name=".ui.onboarding.SignUpActivity"
             android:exported="false" />
@@ -49,8 +52,7 @@
             android:exported="false" />
         <activity
             android:name=".ui.MainActivity"
-            android:exported="true">
-        </activity>
-
+            android:exported="true" />
     </application>
+
 </manifest>

--- a/app/src/main/java/com/android/hanple/ui/onboarding/AuthViewModel.kt
+++ b/app/src/main/java/com/android/hanple/ui/onboarding/AuthViewModel.kt
@@ -16,7 +16,6 @@ class AuthViewModel:ViewModel() {
     //get 사용하므로 _authState 값 바뀔 때마다 authState가 갱신됨.
 
     private val auth: FirebaseAuth = Firebase.auth //firebase auth 가져오기.
-    //앱 실행 전체에서 1번만 선언해도 되므로, LogIn + SignUp ViewModel을 한 곳에 합치기.
 
     fun logIn(email: String, password: String) {
         auth.signInWithEmailAndPassword(email, password)

--- a/app/src/main/java/com/android/hanple/ui/onboarding/AuthViewModel.kt
+++ b/app/src/main/java/com/android/hanple/ui/onboarding/AuthViewModel.kt
@@ -1,0 +1,46 @@
+package com.android.hanple.ui.onboarding
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+
+class AuthViewModel:ViewModel() {
+
+    // (mutable, immutable) LiveData 선언해 주기.
+    private val _authState = MutableLiveData<AuthState>()
+    val authState: LiveData<AuthState> get() = _authState
+    //get 사용하므로 _authState 값 바뀔 때마다 authState가 갱신됨.
+
+    private val auth: FirebaseAuth = Firebase.auth //firebase auth 가져오기.
+    //앱 실행 전체에서 1번만 선언해도 되므로, LogIn + SignUp ViewModel을 한 곳에 합치기.
+
+    fun logIn(email: String, password: String) {
+        auth.signInWithEmailAndPassword(email, password)
+            .addOnCompleteListener{ login ->
+                if(login.isSuccessful) {
+                    _authState.value = AuthState.Success(auth.currentUser) //로그인 성공(현재 유저 정보)
+                }
+                else {
+                    _authState.value = AuthState.Failure(login.exception) //로그인 실패(예외 String)
+                }
+            }
+    }
+
+    fun signUp(email: String, password: String) {
+
+    }
+
+    fun getCurrentUser() = auth.currentUser
+
+    sealed class AuthState {
+        data class Success(val user: FirebaseUser?): AuthState()
+        data class Failure(val exception: Exception?): AuthState()
+
+    }
+
+
+}

--- a/app/src/main/java/com/android/hanple/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/android/hanple/ui/onboarding/OnboardingActivity.kt
@@ -23,7 +23,7 @@ class OnboardingActivity : AppCompatActivity() {
 
         // 회원가입 텍스트뷰 클릭 리스너 설정
         binding.tvSignup.setOnClickListener {
-            val signupIntent = Intent(this, NewAccountActivity::class.java)
+            val signupIntent = Intent(this, SignUpActivity::class.java)
             startActivity(signupIntent)
         }
     }

--- a/app/src/main/java/com/android/hanple/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/android/hanple/ui/onboarding/OnboardingActivity.kt
@@ -2,9 +2,12 @@ package com.android.hanple.ui.onboarding
 
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
 import com.android.hanple.databinding.ActivityOnboardingBinding
+import com.android.hanple.ui.MainActivity
 
 class OnboardingActivity : AppCompatActivity() {
 
@@ -19,6 +22,7 @@ class OnboardingActivity : AppCompatActivity() {
             val email = binding.etEmail.text.toString()
             val password = binding.etPassword.text.toString()
             authViewModel.logIn(email, password)
+            //email이나 password가 하나라도 null이면 현재 앱이 강제 종료됨.
         }
 
         // 회원가입 텍스트뷰 클릭 리스너 설정
@@ -26,5 +30,20 @@ class OnboardingActivity : AppCompatActivity() {
             val signupIntent = Intent(this, SignUpActivity::class.java)
             startActivity(signupIntent)
         }
+
+        authViewModel.authState.observe(this, Observer { authState ->
+            when (authState) {
+                is AuthViewModel.AuthState.Success -> {
+                    Toast.makeText(this, "Firebase Auth 인증 성공!", Toast.LENGTH_SHORT).show()
+                    val intent = Intent(this, MainActivity::class.java)
+                    startActivity(intent)
+                    finish()  // 현재 Activity를 종료하여 뒤로가기 시 로그인 화면이 보이지 않도록 함
+                }
+                is AuthViewModel.AuthState.Failure -> {
+                    Toast.makeText(this, "Firebase Auth 인증 실패: ${authState.exception?.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
+        })
+
     }
 }

--- a/app/src/main/java/com/android/hanple/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/android/hanple/ui/onboarding/OnboardingActivity.kt
@@ -1,0 +1,30 @@
+package com.android.hanple.ui.onboarding
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import com.android.hanple.databinding.ActivityOnboardingBinding
+
+class OnboardingActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityOnboardingBinding
+    private val authViewModel: AuthViewModel by viewModels()
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityOnboardingBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.btnLogin.setOnClickListener {
+            val email = binding.etEmail.text.toString()
+            val password = binding.etPassword.text.toString()
+            authViewModel.logIn(email, password)
+        }
+
+        // 회원가입 텍스트뷰 클릭 리스너 설정
+        binding.tvSignup.setOnClickListener {
+            val signupIntent = Intent(this, NewAccountActivity::class.java)
+            startActivity(signupIntent)
+        }
+    }
+}

--- a/app/src/main/java/com/android/hanple/utils/FireStoreUtils.kt
+++ b/app/src/main/java/com/android/hanple/utils/FireStoreUtils.kt
@@ -1,0 +1,30 @@
+//package com.android.hanple.utils
+//
+//import android.util.Log
+//import com.google.firebase.firestore.FirebaseFirestore
+//
+////https://firebase.google.com/docs/firestore/quickstart?hl=ko#kotlin+ktx
+//class FireStoreUtils {
+//    val db = FirebaseFirestore.getInstance()
+//
+//    val user = hashMapOf(
+//        "id" to "user123",
+//        "name" to " 홍길동",
+//        "password" to "password123",
+//        "phoneNumber" to "+821012345678",
+//    )
+//
+//    fun things(){
+//        db.collection("user-info")
+//            .get()
+//            .addOnSuccessListener { result ->
+//                for (document in result) {
+//                    Log.d("FireStore", "${document.id} => ${document.data}")
+//                }
+//            }
+//            .addOnFailureListener { exception ->
+//                Log.w("FireStore", "Error getting documents.", exception)
+//            }
+//    }
+//
+//}

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:background="@color/white"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.onboarding.LogInActivity">
+
+    <ImageView
+        android:id="@+id/img_profile"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="50dp"
+        android:src="@drawable/smile_icon"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:layout_editor_absoluteY="42dp" />
+
+
+    <EditText
+        android:id="@+id/et_email"
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:layout_marginStart="30dp"
+        android:layout_marginEnd="30dp"
+        android:background="@drawable/edge"
+        android:hint="E-mail"
+        android:text=""
+        android:padding="10dp"
+        android:textColor="#000000"
+        android:textSize="20sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/img_profile" />
+
+    <EditText
+        android:id="@+id/et_password"
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:layout_marginStart="30dp"
+        android:layout_marginEnd="30dp"
+        android:layout_marginTop="12dp"
+        android:background="@drawable/edge"
+        android:hint="Password"
+        android:inputType="textPassword"
+        android:padding="10dp"
+        android:textColor="#000000"
+        android:textSize="20sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/et_email" />
+
+    <View
+        android:id="@+id/view_right"
+        android:layout_width="100dp"
+        android:layout_height="1dp"
+        android:background="#34000000"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/btn_login"
+        app:layout_constraintTop_toBottomOf="@+id/et_password" />
+
+    <View
+        android:id="@+id/view_left"
+        android:layout_width="100dp"
+        android:layout_height="1dp"
+        android:background="#34000000"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/btn_login"
+        app:layout_constraintTop_toBottomOf="@+id/et_password" />
+
+    <android.widget.Button
+        android:id="@+id/btn_login"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="30dp"
+        android:layout_marginEnd="30dp"
+        android:layout_marginTop="30dp"
+        android:background="@drawable/btn_signup"
+        android:text="Log In"
+        android:textSize="18sp"
+        android:textAllCaps="false"
+        android:textColor="@color/darkmint"
+        app:layout_constraintEnd_toEndOf="@+id/et_password"
+        app:layout_constraintStart_toStartOf="@+id/et_password"
+        app:layout_constraintTop_toBottomOf="@+id/et_password" />
+
+    <TextView
+        android:id="@+id/tv_signup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Sign Up?"
+        android:textColor="@color/darkmint"
+        app:layout_constraintBottom_toBottomOf="@+id/view_left"
+        app:layout_constraintEnd_toStartOf="@+id/view_left"
+        app:layout_constraintStart_toEndOf="@+id/view_right"
+        app:layout_constraintTop_toTopOf="@+id/view_left" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,5 +7,6 @@ plugins {
 buildscript {
     dependencies {
         classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1")
+        classpath("com.google.gms:google-services:4.4.2") //firebase firestore
     }
 }


### PR DESCRIPTION
원래는 LogInActivity와 LogInViewModel에 추가되어야 하는 기능입니다.
그런데 계속 코드 추가가 잘 되지 않아, OnboardingAcitivty와 AuthViewModel을 임시로 만들어 두었습니다.

## firebase auth 상에 있는 계정 (및 비밀번호) 스크린샷
![스크린샷 2024-06-07 165437](https://github.com/cococo35/ScorePlace-App/assets/75528131/038e03ee-0f5e-4724-9a2f-e8ebd504e1bc)
![스크린샷 2024-06-07 174105](https://github.com/cococo35/ScorePlace-App/assets/75528131/4812df7e-8af4-4383-9981-4bbc7af957c4)

둘 다 비밀번호 12345678입니다.

## 테스트 영상
[Screen_recording_20240607_175547.webm](https://github.com/cococo35/ScorePlace-App/assets/75528131/ef3e99a0-19b8-4bb6-8995-10782e645695)


## 해야 할 일
- email, password 등 입력정보가 null 일 때 예외처리하기 **(현재는 둘 중 하나라도 null이면 강제 종료됩니다.)**
- OnboardingActivity 코드를 LogInActivity로 옮기고, OnboardingActivity 삭제하기
- AuthViewModel 코드를 LogInViewModel로 옮기고, AuthViewModel 삭제하기
- SignUpViewModel 에서 auth.createUserWithEmailAndPassword(email, password) 메소드를 사용해 앱에서 firebase auth로 계정 추가하기
- 
- 한플 관리용 구글 계정 만들기 (현재는 제 개인 구글 계정에 연결되어 있습니다.)
- 해당 구글 계정에서 한플용 firebase auth 프로젝트 생성 > google-services.json 파일 받아서 교체하기 **(중요!)**
![image](https://github.com/cococo35/ScorePlace-App/assets/75528131/f467540b-104f-4e3d-acd3-2ac140b2c0af)
