### PR TITLE
텍스트 짤림 현상 및 Time Picker 출력  변경

### DIFF
--- a/app/src/main/java/com/android/hanple/ui/search/ScoreFragment.kt
+++ b/app/src/main/java/com/android/hanple/ui/search/ScoreFragment.kt
@@ -233,6 +233,8 @@ class ScoreFragment : Fragment() {
                 transaction.setCustomAnimations(R.anim.to_left, R.anim.from_left)
                 transaction.replace(R.id.fr_main, searchFragment)
                 transaction.commit()
+                viewModel.resetTimeStamp()
+                viewModel.resetTime()
                 (activity as MainActivity).visibleDrawerView()
             }
             .setNegativeButton("No", null)
@@ -347,22 +349,10 @@ class ScoreFragment : Fragment() {
                 address.text = ""
             }
         }
-        viewModel.selectCategoryPlaceSummary.observe(viewLifecycleOwner){
-            if(it != null){
-                summary.text = it
-            }
-            else {
-                summary.text = ""
-            }
-        }
-        viewModel.selectCategoryPlaceOpeningHour.observe(viewLifecycleOwner){
-            if(it != null){
-                openingHour.text = it.hoursType?.toString()
-            }
-            else {
-                openingHour.text = ""
-            }
-        }
+
+        //정보를 제공하는 장소가 너무 적어서 일단 빈 텍스트로 설정
+        summary.text = ""
+        openingHour.text = ""
         closeButton.setOnClickListener {
             dialog.dismiss()
         }

--- a/app/src/main/java/com/android/hanple/ui/search/SearchLoadingFragment.kt
+++ b/app/src/main/java/com/android/hanple/ui/search/SearchLoadingFragment.kt
@@ -1,10 +1,13 @@
 package com.android.hanple.ui.search
 
+import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
+import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -41,6 +44,15 @@ class SearchLoadingFragment : Fragment() {
         _binding = null
     }
 
+    //로딩창에서 기기로 뒤로가기 누르기 막기
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        val callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+            }
+        }
+        requireActivity().onBackPressedDispatcher.addCallback(this@SearchLoadingFragment, callback)
+    }
     private fun initView(){
         lifecycleScope.launch {
             whenStarted{

--- a/app/src/main/java/com/android/hanple/ui/search/SearchTimeFragment.kt
+++ b/app/src/main/java/com/android/hanple/ui/search/SearchTimeFragment.kt
@@ -56,12 +56,14 @@ class SearchTimeFragment : Fragment() {
         getLocalTime()
         initView()
         putViewModelData()
-        createTimePickerBottomView()
+        if(viewModel.readTimeStamp.value == null || viewModel.readTimeStamp.value!!.isEmpty()){
+            createTimePickerBottomView()
+        }
     }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        callback = object : OnBackPressedCallback(true){
+        callback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 val mainDrawer = requireActivity().findViewById<DrawerLayout>(R.id.drawer_layout)
                 if (mainDrawer.isDrawerOpen(GravityCompat.START)) {
@@ -76,6 +78,7 @@ class SearchTimeFragment : Fragment() {
                 }
             }
         }
+
         requireActivity().onBackPressedDispatcher.addCallback(this@SearchTimeFragment, callback)
         (activity as MainActivity).hideDrawerView()
     }
@@ -126,6 +129,26 @@ class SearchTimeFragment : Fragment() {
                 } else {
                     Toast.makeText(requireContext(), "잘못 입력된 정보가 있습니다", Toast.LENGTH_SHORT).show()
                 }
+            }
+        }
+        viewModel.startTime.observe(viewLifecycleOwner){
+            if(it == null || it == "not input"){
+                binding.tvSearchTimeFromHour.text = "00"
+                binding.tvSearchTimeFromMinute.text = "00"
+            }
+            else{
+                binding.tvSearchTimeFromHour.text = it.substring(0,2)
+                binding.tvSearchTimeFromMinute.text = it.substring(2)
+            }
+        }
+        viewModel.endTime.observe(viewLifecycleOwner){
+            if(it == null || it == "not input"){
+                binding.tvSearchTimeToHour.text = "00"
+                binding.tvSearchTimeToMinute.text = "00"
+            }
+            else{
+                binding.tvSearchTimeToHour.text = it.substring(0,2)
+                binding.tvSearchTimeToMinute.text = it.substring(2)
             }
         }
     }
@@ -217,29 +240,25 @@ class SearchTimeFragment : Fragment() {
         val startTimePicker = timePickerBottomSheet.findViewById<TimePicker>(R.id.time_insert_start)
         val endTimePicker = timePickerBottomSheet.findViewById<TimePicker>(R.id.time_insert_end)
         val insertButton = timePickerBottomSheet.findViewById<TextView>(R.id.tv_time_insert_dismiss)
-
+        timePickerBottomSheetView.behavior.state = BottomSheetBehavior.STATE_EXPANDED
         startTimePicker.setOnTimeChangedListener { view, hourOfDay, minute ->
             if (minute < 10) {
                 val minuteText = "0$minute"
                 startTime = "$hourOfDay" + minuteText
-                binding.tvSearchTimeFromHour.text = "$hourOfDay"
-                binding.tvSearchTimeFromMinute.text = minuteText
+                viewModel.getStartTime(startTime)
             } else {
                 startTime = "$hourOfDay" + "$minute"
-                binding.tvSearchTimeFromHour.text = "$hourOfDay"
-                binding.tvSearchTimeFromMinute.text = "$minute"
+                viewModel.getStartTime(startTime)
             }
         }
         endTimePicker.setOnTimeChangedListener { view, hourOfDay, minute ->
             if (minute < 10) {
                 val minuteText = "0$minute"
                 endTime = "$hourOfDay" + minuteText
-                binding.tvSearchTimeToHour.text = "$hourOfDay"
-                binding.tvSearchTimeToMinute.text = minuteText
+                viewModel.getEndTime(endTime)
             } else {
                 endTime = "$hourOfDay" + "$minute"
-                binding.tvSearchTimeToHour.text = "$hourOfDay"
-                binding.tvSearchTimeToMinute.text = "$minute"
+                viewModel.getEndTime(endTime)
             }
         }
 
@@ -247,7 +266,7 @@ class SearchTimeFragment : Fragment() {
             viewModel.getTimeStamp(startTime,endTime)
             timePickerBottomSheetView.dismiss()
         }
-//        timePickerBottomSheetView.setCancelable(false)
+        timePickerBottomSheetView.setCancelable(false)
         timePickerBottomSheetView.show()
     }
 }

--- a/app/src/main/java/com/android/hanple/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/android/hanple/viewmodel/SearchViewModel.kt
@@ -43,7 +43,15 @@ class SearchViewModel(
     private val _Lng = MutableLiveData<String>()
     private val _selectPlace = MutableLiveData<Place?>()
     val selectPlace: LiveData<Place?> get() = _selectPlace
+
+    private val _startTime = MutableLiveData<String>()
+    private val _endTime = MutableLiveData<String>()
+    val startTime : LiveData<String> get() = _startTime
+    val endTime : LiveData<String> get() = _endTime
+
     private val timeStamp = MutableLiveData<List<String>>()
+    val readTimeStamp : LiveData<List<String>> get() = timeStamp
+
     private val placeClient = MutableLiveData<PlacesClient>()
     private val notDrivingCar = MutableLiveData<Boolean>()
 
@@ -116,6 +124,21 @@ class SearchViewModel(
         timeStamp.postValue(list)
     }
 
+    fun resetTimeStamp(){
+        timeStamp.value = emptyList()
+    }
+
+    fun resetTime(){
+        _startTime.value = "not input"
+        _endTime.value = "not input"
+    }
+    fun getStartTime(str : String){
+        _startTime.value = str
+    }
+
+    fun getEndTime(str: String){
+        _endTime.value = str
+    }
     fun getCongestionData(query: String) {
         viewModelScope.launch {
             val list = mutableListOf<String>()
@@ -557,7 +580,13 @@ class SearchViewModel(
         } else {
             (score * 0.5 + 25) - (additionalCount * additionalCount)          // additionalCount 가 양수일 때, 음수일 때 if문으로 나눠 계산
         }
-        _totalScore.postValue(addScore.toInt())
+        _totalScore.value = addScore.toInt()
+        Log.d("날씨 점수", weatherScore.value.toString())
+        Log.d("미세먼지 점수", dustScore.value.toString())
+        Log.d("교통 점수", transportScore.value.toString())
+        Log.d("비용 점수", costScore.value.toString())
+        Log.d("혼잡도 점수", congestScore.value.toString())
+        Log.d("총 점수", _totalScore.value.toString())
     }
     fun resetScore(){
         weatherScore.value = 0

--- a/app/src/main/res/layout/fragment_detail_category_info_dialog.xml
+++ b/app/src/main/res/layout/fragment_detail_category_info_dialog.xml
@@ -2,35 +2,38 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:background="@color/white"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
+    android:layout_height="match_parent"
+    android:padding="16dp">
 
     <TextView
         android:id="@+id/tv_detail_category_info_title"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="60dp"
+        android:layout_marginEnd="16dp"
         android:gravity="center"
-        android:textStyle="bold"
         android:text="장소 이름"
         android:textSize="32sp"
-        android:layout_marginTop="60dp"
-        android:layout_marginBottom="16dp"
-        app:layout_constraintTop_toTopOf="parent"
+        android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/tv_detail_category_info_img"
         android:layout_width="match_parent"
         android:layout_height="200dp"
-        android:layout_marginStart="10dp"
-        android:layout_marginEnd="10dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginStart="16dp"
         android:layout_marginTop="55dp"
-        app:layout_constraintTop_toBottomOf="@+id/tv_detail_category_info_title"
-        android:scaleType="fitXY"/>
+        android:layout_marginEnd="16dp"
+        android:scaleType="fitXY"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tv_detail_category_info_title" />
 
     <ImageView
         android:id="@+id/tv_detail_category_info_null_img"
@@ -45,30 +48,35 @@
         android:src="@drawable/ic_no_image"
         android:visibility="gone"
         />
+
     <TextView
         android:id="@+id/tv_detail_category_info_summary"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="25dp"
+        android:layout_marginStart="16dp"
         android:layout_marginTop="30dp"
-        android:text="장소 정보"
+        android:layout_marginEnd="16dp"
         android:breakStrategy="simple"
+        android:text="장소 정보"
         android:textSize="20sp"
         android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tv_detail_category_info_img" />
 
 
     <TextView
         android:id="@+id/tv_detail_category_info_address"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="25dp"
-        android:layout_marginTop="30dp"
-        android:text="장소 주소"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginEnd="16dp"
         android:breakStrategy="simple"
+        android:text="장소 주소"
         android:textSize="20sp"
         android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tv_detail_category_info_summary" />
 

--- a/app/src/main/res/layout/fragment_insert_time.xml
+++ b/app/src/main/res/layout/fragment_insert_time.xml
@@ -82,6 +82,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         android:layout_marginTop="30dp"
-        app:layout_constraintTop_toBottomOf="@+id/tv_insert_time_to"/>
+        app:layout_constraintTop_toBottomOf="@+id/tv_insert_time_to"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/recyclerview_score_category_item.xml
+++ b/app/src/main/res/layout/recyclerview_score_category_item.xml
@@ -47,23 +47,21 @@
 
             <TextView
                 android:id="@+id/tv_item_address"
-                android:layout_width="160dp"
+                android:layout_width="130dp"
                 android:layout_height="wrap_content"
                 app:layout_constraintStart_toStartOf="parent"
                 android:layout_marginStart="15dp"
                 android:layout_marginTop="10dp"
                 app:layout_constraintTop_toBottomOf="@id/iv_item_thumbnail"
-                android:maxLines="1"
-                android:ellipsize="end"
+                android:breakStrategy="simple"
                 android:text="호우섬 여의도"
-                android:textSize="16sp"
+                android:textSize="14sp"
                 android:textStyle="bold" />
 
             <TextView
                 android:id="@+id/tv_item_time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:layout_constraintStart_toStartOf="@id/tv_item_address"
                 app:layout_constraintTop_toBottomOf="@id/tv_item_address"
                 android:text="오전 10:30 ~ 오후 08:00"
                 android:textSize="14sp" />
@@ -72,22 +70,21 @@
                 android:id="@+id/iv_item_star"
                 android:layout_width="18dp"
                 android:layout_height="18dp"
-                android:layout_marginEnd="3dp"
-                app:layout_constraintEnd_toStartOf="@id/tv_item_grade"
-                app:layout_constraintTop_toTopOf="@id/tv_item_grade"
+                android:background="@drawable/ic_star_filled_18dp"
                 app:layout_constraintBottom_toBottomOf="@id/tv_item_grade"
-                android:background="@drawable/ic_star_filled_18dp" />
+                app:layout_constraintEnd_toStartOf="@+id/tv_item_grade"
+                app:layout_constraintTop_toTopOf="@id/tv_item_grade" />
 
             <TextView
                 android:id="@+id/tv_item_grade"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@id/tv_item_address"
-                app:layout_constraintBottom_toBottomOf="@id/tv_item_address"
-                android:layout_marginEnd="12dp"
+                android:layout_marginEnd="24dp"
                 android:text="4.0"
-                android:textSize="14sp" />
+                android:textSize="14sp"
+                app:layout_constraintBottom_toBottomOf="@id/tv_item_address"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_item_address" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
1. 몇몇 아이템들 텍스트 짤림 현상 수정
2. TIme Picker 입력 후 뒤로 가기 시 다시 입력하기 클릭를 해야만 바텀 시트 출력, 해당 인풋 정보는 결과창에서 처음 화면으로 돌아가야만 초기화