### PR TITLE
refactor: 게스트 로그인 작동 추가, SharedPref에 닉네임 저장

### DIFF
--- a/app/src/main/java/com/android/hanple/ui/MainActivity.kt
+++ b/app/src/main/java/com/android/hanple/ui/MainActivity.kt
@@ -22,6 +22,7 @@ import com.android.hanple.Room.recommendPlaceGoogleID
 import com.android.hanple.databinding.ActivityMainBinding
 import com.android.hanple.ui.search.InitLoadFragment
 import com.android.hanple.ui.settings.SettingsActivity
+import com.android.hanple.ui.settings.SettingsFragment
 import com.android.hanple.viewmodel.SearchViewModel
 import com.android.hanple.viewmodel.SearchViewModelFactory
 import com.google.android.libraries.places.api.Places
@@ -49,6 +50,7 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         insertRoomData()
+        //initSettingsFragment()
         initFragment()
         setNavigation()
         initPlaceSDK()
@@ -64,6 +66,19 @@ class MainActivity : AppCompatActivity() {
         binding.drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
     }
 
+    private fun initSettingsFragment() {
+        val settingsFragment = SettingsFragment()
+        val nickname = intent.getStringExtra("nickname")
+        if (nickname != null) {
+            val bundle = Bundle()
+            bundle.putString("nickname", nickname)
+            settingsFragment.arguments = bundle
+
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.fr_settings, settingsFragment)
+                .commit()
+        }
+    }
 
     private fun initFragment() {
         supportFragmentManager.commit {

--- a/app/src/main/java/com/android/hanple/ui/MainActivity.kt
+++ b/app/src/main/java/com/android/hanple/ui/MainActivity.kt
@@ -48,9 +48,9 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
+        sendLogInInfoToSettings()
         setContentView(binding.root)
         insertRoomData()
-        //initSettingsFragment()
         initFragment()
         setNavigation()
         initPlaceSDK()
@@ -66,17 +66,12 @@ class MainActivity : AppCompatActivity() {
         binding.drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
     }
 
-    private fun initSettingsFragment() {
-        val settingsFragment = SettingsFragment()
+    private fun sendLogInInfoToSettings() {
         val nickname = intent.getStringExtra("nickname")
         if (nickname != null) {
             val bundle = Bundle()
             bundle.putString("nickname", nickname)
-            settingsFragment.arguments = bundle
-
-            supportFragmentManager.beginTransaction()
-                .replace(R.id.fr_settings, settingsFragment)
-                .commit()
+            SettingsFragment().arguments = bundle
         }
     }
 

--- a/app/src/main/java/com/android/hanple/ui/onboarding/AuthViewModel.kt
+++ b/app/src/main/java/com/android/hanple/ui/onboarding/AuthViewModel.kt
@@ -1,5 +1,6 @@
 package com.android.hanple.ui.onboarding
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -13,11 +14,21 @@ class AuthViewModel : ViewModel() {
     // (mutable, immutable) LiveData 선언해 주기.
     private val _authState = MutableLiveData<AuthState>()
     val authState: LiveData<AuthState> get() = _authState
-    //get 사용하므로 _authState 값 바뀔 때마다 authState가 갱신됨.
 
+    sealed class AuthState { //로 observe에서 깔끔하게
+        data class Success(val user: FirebaseUser?) : AuthState()
+        data class Failure(val exception: Exception?) : AuthState()
+    }
     private val auth: FirebaseAuth = Firebase.auth //firebase auth 가져오기.
 
-    fun logIn(email: String?, password: String?): Int {
+    fun guestLogIn() {
+        auth.signInAnonymously().addOnSuccessListener {
+            Log.d("firebase auth", "게스트 로그인 성공")
+        }
+    }
+
+    fun getUid(): String = auth.currentUser?.uid.toString()
+    fun emailLogIn(email: String?, password: String?): Int {
         if (email == null || email == "") return 1
         else if (password == null || password == "") return 2
         else {
@@ -33,15 +44,7 @@ class AuthViewModel : ViewModel() {
         }
     }
 
-    fun getUid(): String {
-        return auth.currentUser?.uid.toString()
-    }
-
-    sealed class AuthState {
-        data class Success(val user: FirebaseUser?) : AuthState()
-        data class Failure(val exception: Exception?) : AuthState()
-
-    }
-
-
 }
+
+
+

--- a/app/src/main/java/com/android/hanple/ui/onboarding/LogInActivity.kt
+++ b/app/src/main/java/com/android/hanple/ui/onboarding/LogInActivity.kt
@@ -53,7 +53,7 @@ class LogInActivity : AppCompatActivity() {
             Toast.makeText(this, "반가워요, $nickname 님!", Toast.LENGTH_SHORT).show()
             val mainIntent = Intent(this, MainActivity::class.java)
             mainIntent.putExtra("nickname", nickname)
-            Log.d("nickname", "$nickname 을 인텐트에 포장해 메인으로 보냄.")
+            Log.d("nickname", "닉네임: $nickname | 인텐트에 포장해 메인으로 보냄.")
             startActivity(mainIntent)
             finish()
         }

--- a/app/src/main/java/com/android/hanple/ui/onboarding/LogInActivity.kt
+++ b/app/src/main/java/com/android/hanple/ui/onboarding/LogInActivity.kt
@@ -10,8 +10,11 @@ import androidx.lifecycle.Observer
 import com.android.hanple.R
 import com.android.hanple.databinding.ActivityLogInBinding
 import com.android.hanple.ui.MainActivity
+import com.android.hanple.utils.GenerateNicknameUtils
+import com.android.hanple.utils.SharedPreferencesUtils
 
 class LogInActivity : AppCompatActivity() {
+
 
     private lateinit var binding: ActivityLogInBinding
     private val authViewModel: AuthViewModel by viewModels()
@@ -24,15 +27,35 @@ class LogInActivity : AppCompatActivity() {
         binding.btnEmailLogin.setOnClickListener {//앱 자체 null 체크
             val email = binding.etEmail.text.toString()
             val password = binding.etPassword.text.toString()
-            val logInChecker: Int = authViewModel.logIn(email, password) //여기서 로그인!
+            val logInChecker: Int = authViewModel.emailLogIn(email, password) //여기서 로그인!
             when(logInChecker) {
                 1 -> Toast.makeText(this, "이메일 란이 비어있어요.", Toast.LENGTH_SHORT).show()
                 2 -> Toast.makeText(this, "비밀번호 란이 비어있어요.", Toast.LENGTH_SHORT).show()
             }
         }
 
-        binding.btnGuestLogin.setOnClickListener{
 
+        binding.btnGuestLogin.setOnClickListener{
+            authViewModel.guestLogIn() //firebase에 게스트 로그인 계정 생성
+
+            val spf = SharedPreferencesUtils(applicationContext)
+            val savedNickname: String? = spf.loadNicknameLocal()
+            lateinit var nickname: String
+
+            if (savedNickname == null) { //저장된 별명이 없을 때 새로 생성해 저장.
+                nickname = GenerateNicknameUtils.generateNickname()
+                spf.saveNicknameLocal(nickname)
+                Log.d("nickname", "별명 생성: $nickname")
+            } else { //저장된 별명이 있을 때
+                nickname = savedNickname
+                Log.d("nickname", "별명이 이미 $nickname 으로 작성되어 있음.")
+            }
+            Toast.makeText(this, "반가워요, $nickname 님!", Toast.LENGTH_SHORT).show()
+            val mainIntent = Intent(this, MainActivity::class.java)
+            mainIntent.putExtra("nickname", nickname)
+            Log.d("nickname", "$nickname 을 인텐트에 포장해 메인으로 보냄.")
+            startActivity(mainIntent)
+            finish()
         }
 
         // 회원가입 텍스트뷰 클릭 리스너 설정

--- a/app/src/main/java/com/android/hanple/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/android/hanple/ui/settings/SettingsFragment.kt
@@ -1,6 +1,7 @@
 package com.android.hanple.ui.settings
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -17,7 +18,9 @@ class SettingsFragment : Fragment() {
     ): View? {
         _binding = FragmentSettingsBinding.inflate(inflater, container, false)
 
-        binding.tvSettingsNicknameValue.text = "hello"
+        val nickname = arguments?.getString("nickname")
+        binding.tvSettingsNicknameValue.text = nickname
+        Log.d("nickname", "전달받은 문구: ${nickname}")
         return binding.root
     }
 

--- a/app/src/main/java/com/android/hanple/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/android/hanple/ui/settings/SettingsFragment.kt
@@ -1,11 +1,10 @@
 package com.android.hanple.ui.settings
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.android.hanple.R
+import androidx.fragment.app.Fragment
 import com.android.hanple.databinding.FragmentSettingsBinding
 
 class SettingsFragment : Fragment() {
@@ -17,6 +16,8 @@ class SettingsFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentSettingsBinding.inflate(inflater, container, false)
+
+        binding.tvSettingsNicknameValue.text = "hello"
         return binding.root
     }
 

--- a/app/src/main/java/com/android/hanple/utils/GenerateNicknameUtils.kt
+++ b/app/src/main/java/com/android/hanple/utils/GenerateNicknameUtils.kt
@@ -1,0 +1,12 @@
+package com.android.hanple.utils
+
+object GenerateNicknameUtils {
+    private val adjectives = listOf( "꼼꼼한", "즐거운", "느긋한", "신나는", "배고픈", "발빠른")
+    private val nouns = listOf( "해치", "고양이", "강아지", "판다", "사자")
+
+    fun generateNickname(): String {
+        val adjective = adjectives.random()
+        val nouns = nouns.random()
+        return "$adjective$nouns"
+    }
+}

--- a/app/src/main/java/com/android/hanple/utils/SharedPreferencesUtils.kt
+++ b/app/src/main/java/com/android/hanple/utils/SharedPreferencesUtils.kt
@@ -5,26 +5,46 @@ import android.content.SharedPreferences
 
 //context 부족해 생긴 오류 디버깅을 했다.
 //참고한 글: https://youngdroidstudy.tistory.com/entry/Kotlin-%EC%BD%94%ED%8B%80%EB%A6%B0%EC%9D%98-SharedPreferences-%EB%9E%80
-class SharedPreferencesUtils(context: Context) { //context 매개변수를 위해 Singleton에서 class로 다시 변경함. 대신 사용하는 Activity에서 companion object로 불러오겠습니다.
-    //추후, 아키텍처에 맞추어 메소드들을 옮겨주시면 됩니다.
-    //내부 함수들이 다 제자리를 찾으면 SharedPreferencesUtils는 사라져도 무방합니다.
+class SharedPreferencesUtils(context: Context) {
+
+    companion object { //참고한 자료: https://tahaben.com.ly/2023/02/using-sharedpreferences-to-save-basic-user-info/
+        private const val FIREBASE_AUTH_LOCAL = "firebase_auth"
+        private const val FIREBASE_EMAIL = "email"
+        private const val FIREBASE_GUEST_UID = "guest_uid"
+    }
 
     //SharedPreferences 읽고 쓰고 지우기 - https://hapen385.tistory.com/29 코드를 참고함.
     private val spf: SharedPreferences =
-        context.getSharedPreferences("remember_me", Context.MODE_PRIVATE)
+        context.getSharedPreferences(FIREBASE_AUTH_LOCAL, Context.MODE_PRIVATE)
 
-    fun rememberMe(email: String) { // sharedPreference에 이메일 저장.
-        val editor: SharedPreferences.Editor = spf.edit()
-        editor.putString("remember_me", email).apply()
+
+    //게스트 로그인 정보: uid
+    fun saveGuestUidLocal(uid: String) {
+        spf.edit()
+            .putString(FIREBASE_GUEST_UID, uid)
+            .apply()
+    }
+    fun loadGuestUidLocal(): String? {
+        return spf.getString(FIREBASE_GUEST_UID, null)
+    }
+    fun deleteGuestUidLocal() {
+        spf.edit()
+            .remove(FIREBASE_EMAIL)
+            .apply()
     }
 
-    //앱 실행 전에 SharedPreferences에 저장된 이메일 정보가 있다 = 로컬에 저장됨 = 자동 로그인.
-    fun loadRememberMe(): String =
-        spf.getString("remember_me", "").toString() //초기값 null 아닌 "" 일 것으로 예상 중.
-    //defValue를 지정하는데도. spf.getStirng 타입이 String? 이라서 좀 놀랐어요.
-
-    fun deleteRememberMe() {
-        val editor = spf.edit()
-        editor.remove("remember_me").apply()
+    //이메일
+    fun saveEmailLocal(email: String) {
+        spf.edit()
+            .putString(FIREBASE_EMAIL, email)
+            .apply()
+    }
+    fun loadEmailLocal(): String? {
+        return spf.getString(FIREBASE_EMAIL, null)
+    }
+    fun deleteEmailLocal() {
+        spf.edit()
+            .remove(FIREBASE_EMAIL)
+            .apply()
     }
 }

--- a/app/src/main/java/com/android/hanple/utils/SharedPreferencesUtils.kt
+++ b/app/src/main/java/com/android/hanple/utils/SharedPreferencesUtils.kt
@@ -11,23 +11,35 @@ class SharedPreferencesUtils(context: Context) {
         private const val FIREBASE_AUTH_LOCAL = "firebase_auth"
         private const val FIREBASE_EMAIL = "email"
         private const val FIREBASE_GUEST_UID = "guest_uid"
+        private const val USER_NICKNAME = "username"
     }
 
     //SharedPreferences 읽고 쓰고 지우기 - https://hapen385.tistory.com/29 코드를 참고함.
-    private val spf: SharedPreferences =
-        context.getSharedPreferences(FIREBASE_AUTH_LOCAL, Context.MODE_PRIVATE)
+    private val spf: SharedPreferences = context.getSharedPreferences(FIREBASE_AUTH_LOCAL, Context.MODE_PRIVATE)
 
-
-    //게스트 로그인 정보: uid
+    //게스트 로그인 정보: uidc
     fun saveGuestUidLocal(uid: String) {
         spf.edit()
             .putString(FIREBASE_GUEST_UID, uid)
             .apply()
     }
     fun loadGuestUidLocal(): String? {
-        return spf.getString(FIREBASE_GUEST_UID, null)
+        return spf.getString(USER_NICKNAME, null)
     }
     fun deleteGuestUidLocal() {
+        spf.edit()
+            .remove(USER_NICKNAME)
+            .apply()
+    }
+    fun saveNicknameLocal(nickname: String) {
+        spf.edit()
+            .putString(USER_NICKNAME, nickname)
+            .apply()
+    }
+    fun loadNicknameLocal(): String? {
+        return spf.getString(FIREBASE_GUEST_UID, null)
+    }
+    fun deleteNicknameLocal() {
         spf.edit()
             .remove(FIREBASE_EMAIL)
             .apply()


### PR DESCRIPTION
## 추가한 기능
[Screen_recording_20240613_201633.webm](https://github.com/cococo35/ScorePlace-App/assets/75528131/a006f792-128a-41dc-af13-24403e4de900)
작동되지 않던 게스트 로그인 버튼을 활성화. firebase auth에서도 잡힙니다.
![image](https://github.com/cococo35/ScorePlace-App/assets/75528131/4aa5f493-0d4f-49ee-961a-432133cfde4a)

## 수정 중인 사항
![image](https://github.com/cococo35/ScorePlace-App/assets/75528131/6d7c0ada-fb0e-468e-9ac6-2fed84dab0ae)
1. SharedPref에 저장되지 않는 현상 수정중

![image](https://github.com/cococo35/ScorePlace-App/assets/75528131/dbc754f5-a364-4136-9667-14b61f4ac671)
2.  LogInActivity -> MainActivity -> SettingsFragment로 보낸 intent arguments 변수가 중간에 끊김.